### PR TITLE
Turn on quiet mode

### DIFF
--- a/agent/src/test/resources/container/Dockerfile
+++ b/agent/src/test/resources/container/Dockerfile
@@ -7,4 +7,4 @@ COPY build/libs/attachme-agent.jar .
 COPY src/test/resources/ForkBomb.java .
 
 # Notifies the host at port 9090, debugger attaches to the container port 9091, so need to expose 9091 inside the host to be able to debug
-CMD ["bash", "-c", "cd /app && javac ForkBomb.java && NO_WAIT=true JAVA_TOOL_OPTIONS='-javaagent:attachme-agent.jar=port:9090,host:172.17.0.1 -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=127.0.0.1:9091' java ForkBomb 0" ]
+CMD ["bash", "-c", "cd /app && javac ForkBomb.java && NO_WAIT=true JAVA_TOOL_OPTIONS='-javaagent:attachme-agent.jar=port:9090,host:172.17.0.1 -agentlib:jdwp=transport=dt_socket,server=y,quiet=y,suspend=y,address=127.0.0.1:9091' java ForkBomb 0" ]

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 5001:5001
     environment:
-      JAVA_TOOL_OPTIONS: "-javaagent:attachme-agent.jar=port:7857,host:172.17.0.1 -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:5001"
+      JAVA_TOOL_OPTIONS: "-javaagent:attachme-agent.jar=port:7857,host:172.17.0.1 -agentlib:jdwp=transport=dt_socket,server=y,quiet=y,suspend=y,address=0.0.0.0:5001"
     entrypoint: java EchoService 8081
 
   client:
@@ -29,5 +29,5 @@ services:
     ports:
       - 5002:5002
     environment:
-      JAVA_TOOL_OPTIONS: "-javaagent:attachme-agent.jar=port:7857,host:172.17.0.1 -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:5002"
+      JAVA_TOOL_OPTIONS: "-javaagent:attachme-agent.jar=port:7857,host:172.17.0.1 -agentlib:jdwp=transport=dt_socket,server=y,quiet=y,suspend=y,address=0.0.0.0:5002"
     entrypoint: java Client echoservice 8081 HelloWorld

--- a/installer.sh
+++ b/installer.sh
@@ -10,7 +10,7 @@ if [ ! -f "${AGENT_PATH}" ]; then
 fi
 if [ ! -f "${HOME}/.attachme" ]; then
   {
-    echo "AM_JDWP_ARGS=\"\${JDWP_ARGS:=transport=dt_socket,server=y,suspend=y,address=*:0}\""
+    echo "AM_JDWP_ARGS=\"\${JDWP_ARGS:=transport=dt_socket,server=y,suspend=y,quiet=y,address=*:0}\""
     echo "echo Using JDWP arguments \${AM_JDWP_ARGS}"
     echo "export JAVA_TOOL_OPTIONS=\"-javaagent:${AGENT_PATH} -agentlib:jdwp=\${AM_JDWP_ARGS}\""
     echo "echo \"AttachMe configured successfully\""
@@ -21,7 +21,7 @@ fi
 cat << EOF
 AttachMe installed successfully
 Usage example:
-   #(Optional) export JDWP_ARGS="transport=dt_socket,server=y,suspend=n,address=127.0.0.1:0"
+   #(Optional) export JDWP_ARGS="transport=dt_socket,server=y,suspend=n,quiet=y,address=127.0.0.1:0"
    source ~/.attachme
    java com.example.Application
 EOF

--- a/plugin/src/main/java/com/attachme/plugin/AttachmeInstaller.java
+++ b/plugin/src/main/java/com/attachme/plugin/AttachmeInstaller.java
@@ -66,7 +66,7 @@ public class AttachmeInstaller {
       "\t$ source ~/.attachme/conf.sh\n" +
       "\t$ java com.example.MyApp\n" +
       "In case you want to modify the port of AttachMe or java debugger (JDWP) arguments\n" +
-      "\t$ JDWP_ARGS=\"transport=dt_socket,server=y,suspend=y,address=127.0.0.1:0\" AM_PORT=9009 source ~/.attachme/conf.sh\n" +
+      "\t$ JDWP_ARGS=\"transport=dt_socket,server=y,suspend=y,quiet=y,address=127.0.0.1:0\" AM_PORT=9009 source ~/.attachme/conf.sh\n" +
       "For more details, questions or bug reports refer to https://github.com/JetBrains/attachme/\n" +
       "***********************************************************************\n";
     log.info(help);

--- a/plugin/src/main/resources/conf.sh
+++ b/plugin/src/main/resources/conf.sh
@@ -2,7 +2,7 @@ VERSION="@ATTACHME_VERSION@"
 
 JDWP_ADDR="${JDWP_ADDR:=127.0.0.1}"
 JDWP_PORT="${JDWP_PORT:=0}"
-JDWP_ARGS="${JDWP_ARGS:=transport=dt_socket,server=y,suspend=y,address=${JDWP_ADDR}:${JDWP_PORT}}"
+JDWP_ARGS="${JDWP_ARGS:=transport=dt_socket,server=y,suspend=y,quiet=y,address=${JDWP_ADDR}:${JDWP_PORT}}"
 
 AM_PORT="${AM_PORT:=7857}"
 AM_JAR="${AM_JAR:=${HOME}/.attachme/attachme-agent-${VERSION}.jar}"

--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ JDWP exit error AGENT_ERROR_TRANSPORT_INIT(197): No transports initialized [debu
 
 To fix it, try to configure AttachMe with port address 127.0.0.1, like this:
 ```
-JDWP_ARGS="transport=dt_socket,server=y,suspend=y,address=127.0.0.1:0" source ~/.attachme/conf.sh
+JDWP_ARGS="transport=dt_socket,server=y,suspend=y,quiet=y,address=127.0.0.1:0" source ~/.attachme/conf.sh
 ```
 
 AttachMe is not compatible with the JMX agent. If you are having problems running it with the auto generated SpringBoot run configuration, most likely disabling JMX will fix the problem.


### PR DESCRIPTION
...to avoid additional output in processes picking up the `JAVA_TOOL_OPTIONS`.

Without quiet mode the process will output something like line below as its first line to stdout, which can cause problems in some situations, i.e. where the output is being consumed by another process.

```
Listening for transport dt_socket at address: 53880
```

fixes: https://github.com/JetBrains/attachme/issues/11