### PR TITLE
Extend version support to latest EAP

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 group = 'com.attachme'
 version = '1.0'
-sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -30,7 +30,7 @@ tasks {
     patchPluginXml {
         changeNotes.set("")
         sinceBuild.set("242")
-        untilBuild.set("242.*")
+        untilBuild.set("243.*")
     }
 
     publishPlugin {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -6,10 +6,12 @@ plugins {
 }
 
 group = "com.attachme"
-version = "1.2.8"
+version = "1.2.9"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
 repositories {
@@ -29,7 +31,7 @@ intellij {
 tasks {
     patchPluginXml {
         changeNotes.set("")
-        sinceBuild.set("242")
+        sinceBuild.set("243")
         untilBuild.set("243.*")
     }
 


### PR DESCRIPTION
I have extended the build number support for AttachMe to the latest EAP of IntelliJ IDEA.