### PR TITLE
Add support for IntelliJ version 2025.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -2,12 +2,12 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.7.0"
+    id("org.jetbrains.intellij.platform") version "2.11.0"
     id("java")
 }
 
 group = "com.attachme"
-version = "1.2.11"
+version = "1.2.12"
 
 java {
     toolchain {
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     intellijPlatform {
-        intellijIdeaCommunity("2025.2")
+        intellijIdea("2025.3")
         bundledPlugin("com.intellij.java")
     }
 }
@@ -37,8 +37,8 @@ dependencies {
 tasks {
     patchPluginXml {
         changeNotes.set("")
-        sinceBuild.set("252")
-        untilBuild.set("252.*")
+        sinceBuild.set("253")
+        untilBuild.set("253.*")
     }
 
     publishPlugin {


### PR DESCRIPTION
Fixes https://github.com/JetBrains/attachme/issues/18.

Includes IntelliJ Platform Gradle Plugin and Gradle version upgrades that are required due to the unification of IntelliJ IDEA Community Edition and IntelliJ IDEA Ultimate in 2025.3.